### PR TITLE
Refactor control panel layout into grouped cards

### DIFF
--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -26,6 +26,28 @@ interface ControlsProps {
   stopAllPlayback: () => void;
 }
 
+const CheckboxControl: React.FC<{
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}> = ({ id, label, checked, onChange }) => (
+  <div className="flex items-center gap-2">
+    <input
+      id={id}
+      type="checkbox"
+      checked={checked}
+      onChange={(e) =>
+        onChange((e.target as HTMLInputElement).checked)
+      }
+      className="h-4 w-4"
+    />
+    <Label htmlFor={id} className="text-base text-white">
+      {label}
+    </Label>
+  </div>
+);
+
 const Controls: React.FC<ControlsProps> = ({ stopAllPlayback }) => {
   const {
     scale,
@@ -54,480 +76,429 @@ const Controls: React.FC<ControlsProps> = ({ stopAllPlayback }) => {
 
   return (
     <div className="controls">
-      <div className="fixed top-0 left-0 right-0 z-50 w-full bg-black/70 backdrop-blur-sm px-4 py-3 border-b border-white/10 shadow-lg text-base md:text-lg text-white flex flex-col gap-2">
-        <div className="w-full overflow-x-auto">
-          <div className="flex flex-nowrap items-end gap-3 min-w-max">
-            {/* 1. Scale */}
-            <div className="flex flex-col gap-1 w-44">
-              <Label className="text-base text-white">Scale</Label>
-              <Select
-                value={scale}
-                onValueChange={(v) => {
-                  stopAllPlayback();
-                  setFormState({ scale: v as ScaleName });
-                }}
-              >
-                <SelectTrigger className="text-base h-10 text-black bg-white">
-                  <SelectValue placeholder="Select scale" />
-                </SelectTrigger>
-                <SelectContent className="bg-white text-black">
-                  {Object.keys(scales).map((s) => (
-                    <SelectItem key={s} value={s}>
-                      {ucFirst(s)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            {/* 2. Phrase */}
-            <div className="flex flex-col gap-1 w-64">
-              <Label className="text-base text-white">Phrase</Label>
-              <Select
-                value={phraseMode}
-                onValueChange={(v) => {
-                  stopAllPlayback();
-                  setFormState({ phraseMode: v as PhraseMode });
-                }}
-              >
-                <SelectTrigger className="text-base h-10 text-black bg-white">
-                  <SelectValue placeholder="Select phrase" />
-                </SelectTrigger>
-                <SelectContent className="bg-white text-black">
-                  {/* Basic Patterns */}
-                  <SelectItem value="full-scale">📈 Full Scale</SelectItem>
-                  <SelectItem value="snake">🐍 Snake Pattern</SelectItem>
-                  <SelectItem value="snake-complex">🐍 Snake Complex</SelectItem>
-                  <SelectItem value="motif-1232">🎵 1-2-3-2 Motif</SelectItem>
-                  
-                  {/* Interval Patterns */}
-                  <SelectItem value="thirds">🎼 Thirds</SelectItem>
-                  <SelectItem value="fourths">🎼 Fourths</SelectItem>
-                  <SelectItem value="sixths">🎼 Sixths</SelectItem>
-                  <SelectItem value="four-note-groups">🎼 Four Note Groups</SelectItem>
-                  
-                  {/* Chord Patterns */}
-                  <SelectItem value="triads">🎹 Triads</SelectItem>
-                  <SelectItem value="sevenths">🎹 Sevenths</SelectItem>
-                  
-                  {/* Rock/Metal Techniques */}
-                  <SelectItem value="alternate-picking">🎸 Alternate Picking</SelectItem>
-                  <SelectItem value="pedal-tone">🎸 Pedal Tone</SelectItem>
-                  <SelectItem value="sequence-asc">🎸 Sequence Up</SelectItem>
-                  <SelectItem value="sequence-desc">🎸 Sequence Down</SelectItem>
-                  <SelectItem value="skip-pattern">🎸 Skip Pattern</SelectItem>
-                  <SelectItem value="sweep-arp">🎸 Sweep Arpeggio</SelectItem>
-                  <SelectItem value="neo-classical">🎸 Neo-Classical</SelectItem>
-                  <SelectItem value="power-chord">🎸 Power Chord</SelectItem>
-                  
-                  {/* Djent/Modern Metal */}
-                  <SelectItem value="djent-palm">🤘 Djent Palm Mute</SelectItem>
-                  <SelectItem value="polyrhythm">🤘 Polyrhythm 7/4</SelectItem>
-                  <SelectItem value="breakdown-chug">🤘 Breakdown Chug</SelectItem>
-                  <SelectItem value="tremolo">🤘 Tremolo Picking</SelectItem>
-                  <SelectItem value="legato-cascade">🤘 Legato Cascade</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            {/* 3. Key */}
-            <div className="flex flex-col gap-1 w-36">
-              <Label className="text-base text-white">Key</Label>
-              <Select
-                value={tone}
-                onValueChange={(v) => {
-                  stopAllPlayback();
-                  setFormState({ tone: v as Tone });
-                }}
-              >
-                <SelectTrigger className="text-base h-10 text-black bg-white">
-                  <SelectValue placeholder="Select key" />
-                </SelectTrigger>
-                <SelectContent className="bg-white text-black">
-                  {tones.map((t) => (
-                    <SelectItem key={t} value={t}>
-                      {t.toUpperCase()}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            {/* 4. Tuning */}
-            <div className="flex flex-col gap-1 w-44">
-              <Label className="text-base text-white">Tuning</Label>
-              <Select
-                value={tuningName}
-                onValueChange={(v) => {
-                  stopAllPlayback();
-                  setFormState({ tuningName: v as TuningName });
-                }}
-              >
-                <SelectTrigger className="text-base h-10 text-black bg-white">
-                  <SelectValue placeholder="Select tuning" />
-                </SelectTrigger>
-                <SelectContent className="bg-white text-black">
-                  {Object.keys(tunings).map((t) => (
-                    <SelectItem key={t} value={t}>
-                      {t}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            {/* 5. BPM */}
-            <div className="flex flex-col gap-1 w-32">
-              <Label htmlFor="bpm" className="text-base text-white">
-                BPM: {bpm}
-              </Label>
-              <Slider
-                id="bpm"
-                min={30}
-                max={700}
-                step={5}
-                value={bpm}
-                onChange={(v) => {
-                  stopAllPlayback();
-                  setFormState({ bpm: v });
-                }}
-                className="h-2 w-32"
-              />
-            </div>
-            {/* 6. Octaves */}
-            <div className="flex flex-col gap-1 w-28">
-              <Label className="text-base text-white">Octaves</Label>
-              <Select
-                value={String(phraseOctaves)}
-                onValueChange={(v) => {
-                  stopAllPlayback();
-                  setFormState({ phraseOctaves: parseInt(v, 10) });
-                }}
-              >
-                <SelectTrigger className="text-base h-10 text-black bg-white">
-                  <SelectValue placeholder="Octaves" />
-                </SelectTrigger>
-                <SelectContent className="bg-white text-black">
-                  {[1, 2, 3, 4, 5].map((n) => (
-                    <SelectItem key={n} value={String(n)}>
-                      {String(n)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            {/* 7. Strings */}
-            <div className="flex flex-col gap-1 w-28">
-              <Label htmlFor="strings" className="text-base text-white">
-                Strings
-              </Label>
-              <Input
-                id="strings"
-                onChange={(e) => {
-                  stopAllPlayback();
-                  setFormState({
-                    strings:
-                      parseInt((e.target as HTMLInputElement).value, 10) || 0,
-                  });
-                }}
-                value={String(strings)}
-                type="number"
-                min={1}
-                max={100}
-                className="text-base h-10"
-              />
-            </div>
-            {/* 8. Frets */}
-            <div className="flex flex-col gap-1 w-28">
-              <Label htmlFor="frets" className="text-base text-white">
-                Frets
-              </Label>
-              <Input
-                id="frets"
-                onChange={(e) => {
-                  stopAllPlayback();
-                  setFormState({
-                    frets:
-                      parseInt((e.target as HTMLInputElement).value, 10) || 0,
-                  });
-                }}
-                value={String(frets)}
-                type="number"
-                min={1}
-                max={100}
-                className="text-base h-10"
-              />
-            </div>
-            {/* 9. Sound */}
-            <div className="flex flex-col gap-1 w-44">
-              <Label className="text-base text-white">Sound</Label>
-              <Select
-                value={soundType}
-                onValueChange={(v) => {
-                  stopAllPlayback();
-                  setFormState({ soundType: v as SoundType });
-                }}
-              >
-                <SelectTrigger className="text-base h-10 text-black bg-white">
-                  <SelectValue placeholder="Select sound" />
-                </SelectTrigger>
-                <SelectContent className="bg-white text-black">
-                  {(
-                    [
-                      { type: "marimba", icon: "🎵", name: "Marimba" },
-                      { type: "sine", icon: "〜", name: "Sine" },
-                      { type: "organ", icon: "🎹", name: "Organ" },
-                      { type: "piano", icon: "🎹", name: "Piano" },
-                      { type: "square", icon: "⬜", name: "Square" },
-                      { type: "saw", icon: "🔺", name: "Saw" },
-                      { type: "guitar-clean", icon: "🎸", name: "Guitar Clean" },
-                      { type: "guitar-distorted", icon: "🎸⚡", name: "Guitar Distorted" },
-                      { type: "bass", icon: "🎸📻", name: "Bass" },
-                      { type: "synth-lead", icon: "🎛️⚡", name: "Synth Lead" },
-                      { type: "synth-pad", icon: "🎛️☁️", name: "Synth Pad" },
-                      { type: "bells", icon: "🔔", name: "Bells" },
-                      { type: "strings", icon: "🎻", name: "Strings" },
-                      { type: "flute", icon: "🪈", name: "Flute" },
-                      { type: "brass", icon: "🎺", name: "Brass" },
-                    ] as { type: SoundType; icon: string; name: string }[]
-                  ).map((s) => (
-                    <SelectItem key={s.type} value={s.type}>
-                      {s.icon} {s.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            {/* 10. Trail */}
-            <div className="flex flex-col gap-1 w-36">
-              <Label htmlFor="trailLength" className="text-base text-white">
-                Trail: {trailLength}ms
-              </Label>
-              <Slider
-                id="trailLength"
-                min={100}
-                max={4000}
-                step={50}
-                value={trailLength}
-                onChange={(v) => {
-                  stopAllPlayback();
-                  setFormState({ trailLength: v });
-                }}
-                className="h-2 w-36"
-              />
-            </div>
-            {/* 11. Schedule */}
-            <div className="flex flex-col gap-1 w-36">
-              <Label htmlFor="scheduleHorizon" className="text-base text-white">
-                Schedule (ms)
-              </Label>
-              <Input
-                id="scheduleHorizon"
-                type="number"
-                min={200}
-                max={5000}
-                step={100}
-                value={String(scheduleHorizon)}
-                onChange={(e) => {
-                  const v = parseInt((e.target as HTMLInputElement).value, 10);
-                  if (!Number.isNaN(v)) {
+      <div className="fixed top-0 left-0 right-0 z-50 w-full border-b border-white/10 bg-black/70 px-4 py-4 text-base text-white shadow-lg backdrop-blur-md">
+        <div className="w-full overflow-x-auto pb-1">
+          <div className="min-w-[900px] md:min-w-0 grid gap-4 md:grid-cols-3">
+            {/* Scale & phrase grouping */}
+            <section className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur">
+              <header className="flex items-center gap-2 text-lg font-semibold">
+                <span className="text-2xl" aria-hidden>
+                  🎵
+                </span>
+                <span>Scale</span>
+              </header>
+              <div className="grid gap-3">
+                <div className="grid gap-1">
+                  <Label className="text-base text-white">Scale</Label>
+                  <Select
+                    value={scale}
+                    onValueChange={(v) => {
+                      stopAllPlayback();
+                      setFormState({ scale: v as ScaleName });
+                    }}
+                  >
+                    <SelectTrigger className="h-10 bg-white text-base text-black">
+                      <SelectValue placeholder="Select scale" />
+                    </SelectTrigger>
+                    <SelectContent className="bg-white text-black">
+                      {Object.keys(scales).map((s) => (
+                        <SelectItem key={s} value={s}>
+                          {ucFirst(s)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="grid gap-1">
+                    <Label className="text-base text-white">Key</Label>
+                    <Select
+                      value={tone}
+                      onValueChange={(v) => {
+                        stopAllPlayback();
+                        setFormState({ tone: v as Tone });
+                      }}
+                    >
+                      <SelectTrigger className="h-10 bg-white text-base text-black">
+                        <SelectValue placeholder="Select key" />
+                      </SelectTrigger>
+                      <SelectContent className="bg-white text-black">
+                        {tones.map((t) => (
+                          <SelectItem key={t} value={t}>
+                            {t.toUpperCase()}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="grid gap-1">
+                    <Label className="text-base text-white">Start octave</Label>
+                    <Select
+                      value={String(startOctave)}
+                      onValueChange={(v) => {
+                        stopAllPlayback();
+                        setFormState({ startOctave: parseInt(v, 10) });
+                      }}
+                    >
+                      <SelectTrigger className="h-10 bg-white text-base text-black">
+                        <SelectValue placeholder="Octave" />
+                      </SelectTrigger>
+                      <SelectContent className="bg-white text-black">
+                        {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map((n) => (
+                          <SelectItem key={n} value={String(n)}>
+                            {String(n)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+                <div className="grid gap-1">
+                  <Label className="text-base text-white">Phrase</Label>
+                  <Select
+                    value={phraseMode}
+                    onValueChange={(v) => {
+                      stopAllPlayback();
+                      setFormState({ phraseMode: v as PhraseMode });
+                    }}
+                  >
+                    <SelectTrigger className="h-10 bg-white text-base text-black">
+                      <SelectValue placeholder="Select phrase" />
+                    </SelectTrigger>
+                    <SelectContent className="bg-white text-black">
+                      <SelectItem value="full-scale">📈 Full Scale</SelectItem>
+                      <SelectItem value="snake">🐍 Snake Pattern</SelectItem>
+                      <SelectItem value="snake-complex">🐍 Snake Complex</SelectItem>
+                      <SelectItem value="motif-1232">🎵 1-2-3-2 Motif</SelectItem>
+                      <SelectItem value="thirds">🎼 Thirds</SelectItem>
+                      <SelectItem value="fourths">🎼 Fourths</SelectItem>
+                      <SelectItem value="sixths">🎼 Sixths</SelectItem>
+                      <SelectItem value="four-note-groups">🎼 Four Note Groups</SelectItem>
+                      <SelectItem value="triads">🎹 Triads</SelectItem>
+                      <SelectItem value="sevenths">🎹 Sevenths</SelectItem>
+                      <SelectItem value="alternate-picking">🎸 Alternate Picking</SelectItem>
+                      <SelectItem value="pedal-tone">🎸 Pedal Tone</SelectItem>
+                      <SelectItem value="sequence-asc">🎸 Sequence Up</SelectItem>
+                      <SelectItem value="sequence-desc">🎸 Sequence Down</SelectItem>
+                      <SelectItem value="skip-pattern">🎸 Skip Pattern</SelectItem>
+                      <SelectItem value="sweep-arp">🎸 Sweep Arpeggio</SelectItem>
+                      <SelectItem value="neo-classical">🎸 Neo-Classical</SelectItem>
+                      <SelectItem value="power-chord">🎸 Power Chord</SelectItem>
+                      <SelectItem value="djent-palm">🤘 Djent Palm Mute</SelectItem>
+                      <SelectItem value="polyrhythm">🤘 Polyrhythm 7/4</SelectItem>
+                      <SelectItem value="breakdown-chug">🤘 Breakdown Chug</SelectItem>
+                      <SelectItem value="tremolo">🤘 Tremolo Picking</SelectItem>
+                      <SelectItem value="legato-cascade">🤘 Legato Cascade</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="grid gap-1">
+                    <Label className="text-base text-white">Octaves</Label>
+                    <Select
+                      value={String(phraseOctaves)}
+                      onValueChange={(v) => {
+                        stopAllPlayback();
+                        setFormState({ phraseOctaves: parseInt(v, 10) });
+                      }}
+                    >
+                      <SelectTrigger className="h-10 bg-white text-base text-black">
+                        <SelectValue placeholder="Octaves" />
+                      </SelectTrigger>
+                      <SelectContent className="bg-white text-black">
+                        {[1, 2, 3, 4, 5].map((n) => (
+                          <SelectItem key={n} value={String(n)}>
+                            {String(n)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="grid gap-2">
+                    <CheckboxControl
+                      id="phraseDescend"
+                      label="Descend"
+                      checked={phraseDescend}
+                      onChange={(checked) => {
+                        stopAllPlayback();
+                        setFormState({ phraseDescend: checked });
+                      }}
+                    />
+                    <CheckboxControl
+                      id="phraseLoop"
+                      label="Loop"
+                      checked={phraseLoop}
+                      onChange={(checked) => {
+                        stopAllPlayback();
+                        setFormState({ phraseLoop: checked });
+                      }}
+                    />
+                    <CheckboxControl
+                      id="oncePerTone"
+                      label="Once per tone"
+                      checked={oncePerTone}
+                      onChange={(checked) => {
+                        stopAllPlayback();
+                        setFormState({ oncePerTone: checked });
+                      }}
+                    />
+                  </div>
+                </div>
+              </div>
+              <div className="grid gap-2 border-t border-white/10 pt-3">
+                <span className="text-sm font-semibold uppercase tracking-wide text-white/70">
+                  Highlights
+                </span>
+                <CheckboxControl
+                  id="highlightEnabled"
+                  label="Highlight notes"
+                  checked={highlightEnabled}
+                  onChange={(checked) => {
                     stopAllPlayback();
-                    setFormState({
-                      scheduleHorizon: Math.min(5000, Math.max(200, v)),
-                    });
-                  }
-                }}
-                className="h-10 w-28 text-base"
-              />
-            </div>
-            {/* 12. Start octave */}
-            <div className="flex flex-col gap-1 w-36">
-              <Label className="text-base text-white">Start octave</Label>
-              <Select
-                value={String(startOctave)}
-                onValueChange={(v) => {
-                  stopAllPlayback();
-                  setFormState({ startOctave: parseInt(v, 10) });
-                }}
-              >
-                <SelectTrigger className="text-base h-10 text-black bg-white">
-                  <SelectValue placeholder="Octave" />
-                </SelectTrigger>
-                <SelectContent className="bg-white text-black">
-                  {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map((n) => (
-                    <SelectItem key={n} value={String(n)}>
-                      {String(n)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-        </div>
-        <div className="w-full flex items-center gap-4 flex-wrap">
-          <div className="flex items-center gap-2 h-10">
-            <input
-              id="lowAtBottom"
-              type="checkbox"
-              checked={lowAtBottom}
-              onChange={(e) => {
-                stopAllPlayback();
-                setFormState({
-                  lowAtBottom: (e.target as HTMLInputElement).checked,
-                });
-              }}
-              className="h-4 w-4"
-            />
-            <Label htmlFor="lowAtBottom" className="text-base text-white">
-              Low string at bottom
-            </Label>
-          </div>
-          <div className="flex items-center gap-2 h-10">
-            <input
-              id="highlightEnabled"
-              type="checkbox"
-              checked={highlightEnabled}
-              onChange={(e) => {
-                stopAllPlayback();
-                setFormState({
-                  highlightEnabled: (e.target as HTMLInputElement).checked,
-                });
-              }}
-              className="h-4 w-4"
-            />
-            <Label htmlFor="highlightEnabled" className="text-base text-white">
-              Highlight notes
-            </Label>
-          </div>
-          <div className="flex items-center gap-2 h-10">
-            <input
-              id="legendOnly"
-              type="checkbox"
-              checked={legendOnly}
-              onChange={(e) => {
-                stopAllPlayback();
-                setFormState({
-                  legendOnly: (e.target as HTMLInputElement).checked,
-                });
-              }}
-              className="h-4 w-4"
-            />
-            <Label htmlFor="legendOnly" className="text-base text-white">
-              Legend only
-            </Label>
-          </div>
-          <div className="flex items-center gap-2 h-10">
-            <input
-              id="octaveHighlight"
-              type="checkbox"
-              checked={octaveHighlight}
-              onChange={(e) => {
-                stopAllPlayback();
-                setFormState({
-                  octaveHighlight: (e.target as HTMLInputElement).checked,
-                });
-              }}
-              className="h-4 w-4"
-            />
-            <Label htmlFor="octaveHighlight" className="text-base text-white">
-              Octave highlight
-            </Label>
-          </div>
-          <div className="flex items-center gap-2 h-10">
-            <input
-              id="minimalHighlight"
-              type="checkbox"
-              checked={minimalHighlight}
-              onChange={(e) => {
-                stopAllPlayback();
-                setFormState({
-                  minimalHighlight: (e.target as HTMLInputElement).checked,
-                });
-              }}
-              className="h-4 w-4"
-            />
-            <Label htmlFor="minimalHighlight" className="text-base text-white">
-              Minimal highlight
-            </Label>
-          </div>
-          <div className="flex items-center gap-2 h-10">
-            <input
-              id="reduceAnimations"
-              type="checkbox"
-              checked={reduceAnimations}
-              onChange={(e) => {
-                stopAllPlayback();
-                setFormState({
-                  reduceAnimations: (e.target as HTMLInputElement).checked,
-                });
-              }}
-              className="h-4 w-4"
-            />
-            <Label htmlFor="reduceAnimations" className="text-base text-white">
-              Reduce animations
-            </Label>
-          </div>
-          <div className="flex items-center gap-2 h-10">
-            <input
-              id="oncePerTone"
-              type="checkbox"
-              checked={oncePerTone}
-              onChange={(e) => {
-                stopAllPlayback();
-                setFormState({
-                  oncePerTone: (e.target as HTMLInputElement).checked,
-                });
-              }}
-              className="h-4 w-4"
-            />
-            <Label htmlFor="oncePerTone" className="text-base text-white">
-              Once per tone
-            </Label>
-          </div>
-          <div className="flex items-center gap-2 h-10">
-            <input
-              id="swing2"
-              type="checkbox"
-              checked={swing}
-              onChange={(e) => {
-                stopAllPlayback();
-                setFormState({ swing: (e.target as HTMLInputElement).checked });
-              }}
-              className="h-4 w-4"
-            />
-            <Label htmlFor="swing2" className="text-base text-white">
-              Swing
-            </Label>
-          </div>
-          <div className="flex items-center gap-2 h-10">
-            <input
-              id="descend"
-              type="checkbox"
-              checked={phraseDescend}
-              onChange={(e) => {
-                stopAllPlayback();
-                setFormState({
-                  phraseDescend: (e.target as HTMLInputElement).checked,
-                });
-              }}
-              className="h-4 w-4"
-            />
-            <Label htmlFor="descend" className="text-base text-white">
-              Descend
-            </Label>
-          </div>
-          <div className="flex items-center gap-2 h-10">
-            <input
-              id="loop"
-              type="checkbox"
-              checked={phraseLoop}
-              onChange={(e) => {
-                stopAllPlayback();
-                setFormState({
-                  phraseLoop: (e.target as HTMLInputElement).checked,
-                });
-              }}
-              className="h-4 w-4"
-            />
-            <Label htmlFor="loop" className="text-base text-white">
-              Loop
-            </Label>
+                    setFormState({ highlightEnabled: checked });
+                  }}
+                />
+                <CheckboxControl
+                  id="legendOnly"
+                  label="Legend only"
+                  checked={legendOnly}
+                  onChange={(checked) => {
+                    stopAllPlayback();
+                    setFormState({ legendOnly: checked });
+                  }}
+                />
+                <CheckboxControl
+                  id="octaveHighlight"
+                  label="Octave highlight"
+                  checked={octaveHighlight}
+                  onChange={(checked) => {
+                    stopAllPlayback();
+                    setFormState({ octaveHighlight: checked });
+                  }}
+                />
+                <CheckboxControl
+                  id="minimalHighlight"
+                  label="Minimal highlight"
+                  checked={minimalHighlight}
+                  onChange={(checked) => {
+                    stopAllPlayback();
+                    setFormState({ minimalHighlight: checked });
+                  }}
+                />
+              </div>
+            </section>
+
+            {/* Instrument grouping */}
+            <section className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur">
+              <header className="flex items-center gap-2 text-lg font-semibold">
+                <span className="text-2xl" aria-hidden>
+                  🎸
+                </span>
+                <span>Instrument</span>
+              </header>
+              <div className="grid gap-3">
+                <div className="grid gap-1">
+                  <Label className="text-base text-white">Tuning</Label>
+                  <Select
+                    value={tuningName}
+                    onValueChange={(v) => {
+                      stopAllPlayback();
+                      setFormState({ tuningName: v as TuningName });
+                    }}
+                  >
+                    <SelectTrigger className="h-10 bg-white text-base text-black">
+                      <SelectValue placeholder="Select tuning" />
+                    </SelectTrigger>
+                    <SelectContent className="bg-white text-black">
+                      {Object.keys(tunings).map((t) => (
+                        <SelectItem key={t} value={t}>
+                          {t}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="grid gap-1">
+                    <Label htmlFor="strings" className="text-base text-white">
+                      Strings
+                    </Label>
+                    <Input
+                      id="strings"
+                      onChange={(e) => {
+                        stopAllPlayback();
+                        setFormState({
+                          strings:
+                            parseInt((e.target as HTMLInputElement).value, 10) || 0,
+                        });
+                      }}
+                      value={String(strings)}
+                      type="number"
+                      min={1}
+                      max={100}
+                      className="h-10 text-base"
+                    />
+                  </div>
+                  <div className="grid gap-1">
+                    <Label htmlFor="frets" className="text-base text-white">
+                      Frets
+                    </Label>
+                    <Input
+                      id="frets"
+                      onChange={(e) => {
+                        stopAllPlayback();
+                        setFormState({
+                          frets:
+                            parseInt((e.target as HTMLInputElement).value, 10) || 0,
+                        });
+                      }}
+                      value={String(frets)}
+                      type="number"
+                      min={1}
+                      max={100}
+                      className="h-10 text-base"
+                    />
+                  </div>
+                </div>
+                <div className="grid gap-1">
+                  <Label className="text-base text-white">Sound</Label>
+                  <Select
+                    value={soundType}
+                    onValueChange={(v) => {
+                      stopAllPlayback();
+                      setFormState({ soundType: v as SoundType });
+                    }}
+                  >
+                    <SelectTrigger className="h-10 bg-white text-base text-black">
+                      <SelectValue placeholder="Select sound" />
+                    </SelectTrigger>
+                    <SelectContent className="bg-white text-black">
+                      {(
+                        [
+                          { type: "marimba", icon: "🎵", name: "Marimba" },
+                          { type: "sine", icon: "〜", name: "Sine" },
+                          { type: "organ", icon: "🎹", name: "Organ" },
+                          { type: "piano", icon: "🎹", name: "Piano" },
+                          { type: "square", icon: "⬜", name: "Square" },
+                          { type: "saw", icon: "🔺", name: "Saw" },
+                          { type: "guitar-clean", icon: "🎸", name: "Guitar Clean" },
+                          { type: "guitar-distorted", icon: "🎸⚡", name: "Guitar Distorted" },
+                          { type: "bass", icon: "🎸📻", name: "Bass" },
+                          { type: "synth-lead", icon: "🎛️⚡", name: "Synth Lead" },
+                          { type: "synth-pad", icon: "🎛️☁️", name: "Synth Pad" },
+                          { type: "bells", icon: "🔔", name: "Bells" },
+                          { type: "strings", icon: "🎻", name: "Strings" },
+                          { type: "flute", icon: "🪈", name: "Flute" },
+                          { type: "brass", icon: "🎺", name: "Brass" },
+                        ] as { type: SoundType; icon: string; name: string }[]
+                      ).map((s) => (
+                        <SelectItem key={s.type} value={s.type}>
+                          {s.icon} {s.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <div className="border-t border-white/10 pt-3">
+                <CheckboxControl
+                  id="lowAtBottom"
+                  label="Low string at bottom"
+                  checked={lowAtBottom}
+                  onChange={(checked) => {
+                    stopAllPlayback();
+                    setFormState({ lowAtBottom: checked });
+                  }}
+                />
+              </div>
+            </section>
+
+            {/* Playback grouping */}
+            <section className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur">
+              <header className="flex items-center gap-2 text-lg font-semibold">
+                <span className="text-2xl" aria-hidden>
+                  ▶
+                </span>
+                <span>Playback</span>
+              </header>
+              <div className="grid gap-3">
+                <div className="grid gap-1">
+                  <Label htmlFor="bpm" className="text-base text-white">
+                    BPM: {bpm}
+                  </Label>
+                  <Slider
+                    id="bpm"
+                    min={30}
+                    max={700}
+                    step={5}
+                    value={bpm}
+                    onChange={(v) => {
+                      stopAllPlayback();
+                      setFormState({ bpm: v });
+                    }}
+                  />
+                </div>
+                <div className="grid gap-1">
+                  <Label htmlFor="trailLength" className="text-base text-white">
+                    Trail: {trailLength}ms
+                  </Label>
+                  <Slider
+                    id="trailLength"
+                    min={100}
+                    max={4000}
+                    step={50}
+                    value={trailLength}
+                    onChange={(v) => {
+                      stopAllPlayback();
+                      setFormState({ trailLength: v });
+                    }}
+                  />
+                </div>
+                <div className="grid gap-1">
+                  <Label htmlFor="scheduleHorizon" className="text-base text-white">
+                    Schedule horizon (ms)
+                  </Label>
+                  <Input
+                    id="scheduleHorizon"
+                    type="number"
+                    min={200}
+                    max={5000}
+                    step={100}
+                    value={String(scheduleHorizon)}
+                    onChange={(e) => {
+                      const v = parseInt((e.target as HTMLInputElement).value, 10);
+                      if (!Number.isNaN(v)) {
+                        stopAllPlayback();
+                        setFormState({
+                          scheduleHorizon: Math.min(5000, Math.max(200, v)),
+                        });
+                      }
+                    }}
+                    className="h-10 text-base"
+                  />
+                </div>
+              </div>
+              <div className="grid gap-2 border-t border-white/10 pt-3">
+                <CheckboxControl
+                  id="swing"
+                  label="Swing"
+                  checked={swing}
+                  onChange={(checked) => {
+                    stopAllPlayback();
+                    setFormState({ swing: checked });
+                  }}
+                />
+                <CheckboxControl
+                  id="reduceAnimations"
+                  label="Reduce animations"
+                  checked={reduceAnimations}
+                  onChange={(checked) => {
+                    stopAllPlayback();
+                    setFormState({ reduceAnimations: checked });
+                  }}
+                />
+              </div>
+            </section>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- redesign the fixed control bar into three themed cards for scale, instrument, and playback settings
- extract a reusable CheckboxControl helper to simplify rendering of repeated toggle inputs
- reorganize phrase, highlighting, and playback options into clearer sections with consistent styling

## Testing
- npm test -- --run *(fails: vitest executable unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f13a9c4ec0832eb789c819dc7fc694