### PR TITLE
Ensure pausing stops all scheduled playback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import Controls from '@/components/Controls';
 import Guitar from '@/components/guitar/Guitar';
 import { useFormStore } from '@/store';
 import { toneAnimationManager } from '@/lib/tone-animation';
+import { scheduler } from '@/scheduler';
+import { stopAllAudio } from '@/audio';
 
 const App: React.FC = () => {
   // Playback highlight state lives locally
@@ -14,6 +16,8 @@ const App: React.FC = () => {
   const playingTimersRef = React.useRef<Record<number, number>>({});
 
   const stopAllPlayback = () => {
+    scheduler.stopAll();
+    stopAllAudio();
     Object.values(playingTimersRef.current).forEach((tid) => {
       try { window.clearTimeout(tid); } catch {}
     });

--- a/src/components/guitar/ScaleLegend.tsx
+++ b/src/components/guitar/ScaleLegend.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useRef } from 'react';
 import { keyToOffset, getScalePitchClasses, getNote } from '@/music';
 import { ScaleName, PhraseMode, scales } from '@/constants';
 import { Play } from 'lucide-react';
-import { getCurrentTime, SoundType } from '@/audio';
+import { getCurrentTime, SoundType, stopAllAudio } from '@/audio';
 import { scheduler } from '@/scheduler';
 import { buildRelSequence } from '@/phrases';
 import { toneAnimationManager } from '@/lib/tone-animation';
@@ -41,6 +41,7 @@ const ScaleLegend: React.FC<Props & { descend?: boolean; loop?: boolean }> = ({ 
       scheduler.stopSession(schedulerSessionRef.current);
       schedulerSessionRef.current = null;
     }
+    stopAllAudio();
   };
 
   // Pre-compute the entire sequence for optimized playback


### PR DESCRIPTION
## Summary
- track active audio voices so `stopAllAudio` can immediately silence scheduled tones
- stop scheduler sessions and audio when pausing or switching playback controls to avoid overlapping scales

## Testing
- npm test -- --runTestsByPath src/music.test.ts *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f13c5844b8832e858d30a7750323a3