### PR TITLE
Add keyboard shortcut to toggle playback and sync play button state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,8 +14,9 @@ const App: React.FC = () => {
   const [playingAbs, setPlayingAbs] = React.useState<number | null>(null);
   const [playingSet, setPlayingSet] = React.useState<number[]>([]);
   const playingTimersRef = React.useRef<Record<number, number>>({});
+  const [stopSignal, setStopSignal] = React.useState(0);
 
-  const stopAllPlayback = () => {
+  const stopAllPlayback = React.useCallback(() => {
     scheduler.stopAll();
     stopAllAudio();
     Object.values(playingTimersRef.current).forEach((tid) => {
@@ -24,10 +25,11 @@ const App: React.FC = () => {
     playingTimersRef.current = {};
     setPlayingSet([]);
     setPlayingAbs(null);
-    
+
     // Stop tone-based animations
     toneAnimationManager.stopAll();
-  };
+    setStopSignal((cur) => cur + 1);
+  }, []);
 
   const flashPlaying = (absSemitone: number, durationMs = 200) => {
     setPlayingAbs(absSemitone);
@@ -57,6 +59,7 @@ const App: React.FC = () => {
           playingSet={playingSet}
           onPlayNote={flashPlaying}
           stopAllPlayback={stopAllPlayback}
+          stopSignal={stopSignal}
         />
       </main>
     </div>

--- a/src/components/guitar/Guitar.tsx
+++ b/src/components/guitar/Guitar.tsx
@@ -10,9 +10,10 @@ type Props = {
   playingSet?: number[];
   onPlayNote?: (absSemitone: number, durationMs?: number) => void;
   stopAllPlayback?: () => void;
+  stopSignal?: number;
 };
 
-const Guitar: React.FC<Props> = ({ playingAbs, playingSet, onPlayNote, stopAllPlayback }) => {
+const Guitar: React.FC<Props> = ({ playingAbs, playingSet, onPlayNote, stopAllPlayback, stopSignal }) => {
   const {
     strings,
     frets,
@@ -94,6 +95,7 @@ const Guitar: React.FC<Props> = ({ playingAbs, playingSet, onPlayNote, stopAllPl
         scheduleHorizon={scheduleHorizon}
         onPlayNote={onPlayNote}
         stopAllPlayback={stopAllPlayback}
+        stopSignal={stopSignal}
         soundType={soundType}
         reduceAnimations={reduceAnimations}
         minimalHighlight={minimalHighlight}


### PR DESCRIPTION
## Summary
- add a global Ctrl/Cmd+Enter keyboard shortcut to toggle the phrase playback button
- track a playback stop signal so the Play button returns to the paused state when playback is stopped externally
- ensure local playback timers cancel cleanly when playback is stopped

## Testing
- npm run build *(fails: existing repository TypeScript configuration errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f7fb98cb70832e88d84837035ce5c9